### PR TITLE
Use hash equals in return_handler

### DIFF
--- a/includes/class-payment-gateway.php
+++ b/includes/class-payment-gateway.php
@@ -799,7 +799,7 @@ class WC_Gateway_Simplify_Commerce extends WC_Payment_Gateway_CC {
 			$order_id  = absint( $_REQUEST['reference'] );
 			$order     = wc_get_order( $order_id );
 
-			if ( $signature === $_REQUEST['signature'] ) {
+			if ( hash_equals( $signature, $_REQUEST['signature'] ) ) {
 				$order_complete = $this->process_order_status( $order, $_REQUEST['paymentId'], $_REQUEST['paymentStatus'], $_REQUEST['paymentDate'] );
 
 				if ( ! $order_complete ) {


### PR DESCRIPTION
Using hash_equals helps prevent timing attacks.