### PR TITLE
workaround for non-latin iso character issues

### DIFF
--- a/includes/class-payment-gateway.php
+++ b/includes/class-payment-gateway.php
@@ -499,8 +499,7 @@ class WC_Gateway_Simplify_Commerce extends WC_Payment_Gateway_CC {
 			// Charge the customer
 			$data = array(
 				'amount'      => $this->get_total(), // In cents. Rounding to avoid floating point errors.
-				'description' => sprintf( __( '%s - Order #%s', 'woocommerce' ),
-					$order->get_order_number() ),
+				'description' => sprintf( __( '%s - Order #%s', 'woocommerce' ), $order->get_order_number() ),
 				'currency'    => strtoupper( get_woocommerce_currency() ),
 				'reference'   => $order->get_id()
 			);

--- a/includes/class-payment-gateway.php
+++ b/includes/class-payment-gateway.php
@@ -596,7 +596,7 @@ class WC_Gateway_Simplify_Commerce extends WC_Payment_Gateway_CC {
 		$encode = mb_detect_encoding($field);
 		if ($encode !== 'ASCII') {
 		    if (function_exists('transliterator_transliterate')) {
-		        $field = transliterator_transliterate('Any-Latin; Latin-ASCII; [u0080-u7fff] remove', $field);
+		        $field = transliterator_transliterate('Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove', $field);
 		    } else {
 		        // fall back to iconv if intl module not available
 		        $field = remove_accents($field);

--- a/includes/class-subscription-addon.php
+++ b/includes/class-subscription-addon.php
@@ -386,8 +386,7 @@ class WC_Addons_Gateway_Simplify_Commerce extends WC_Gateway_Simplify_Commerce {
 			// Charge the customer
 			$data = array(
 				'amount'      => $amount * 100, // In cents.
-				'description' => sprintf( __( '%s - Order #%s', 'woocommerce' ),
-					esc_html( get_bloginfo( 'name', 'display' ) ), $order->get_order_number() ),
+				'description' => sprintf( __( '%s - Order #%s', 'woocommerce' ), $order->get_order_number() ),
 				'currency'    => strtoupper( get_woocommerce_currency() ),
 				'reference'   => $order->get_id()
 			);
@@ -528,7 +527,6 @@ class WC_Addons_Gateway_Simplify_Commerce extends WC_Gateway_Simplify_Commerce {
 			$order_items    = $order->get_items();
 			$order_item     = array_shift( $order_items );
 			$pre_order_name = sprintf( __( '%s - Pre-order for "%s"', 'woocommerce' ),
-					esc_html( get_bloginfo( 'name', 'display' ) ),
 					$order_item['name'] ) . ' ' . sprintf( __( '(Order #%s)', 'woocommerce' ),
 					$order->get_order_number() );
 


### PR DESCRIPTION
This a workaround for the issues found with non-latin (e.g. Greek or Arabic) characters.

Fields which are optional and are known to cause issues with payment going through have been removed (and also talked to product about the pros/cons of this).

In the case of bloginfo, I have noticed issues with max length 400 responses, where escaping can cause it to go over various character limits, 255 in the case of description. Note that even with esc_html removed, it can end up escaped again, like in the button for the hosted payment, that is ultimately attribute escaped. NB: PHP escape functions will never double encode, so that is why double escaping is possible.